### PR TITLE
Fix Wreorder warning.

### DIFF
--- a/src/data/can/arm.h
+++ b/src/data/can/arm.h
@@ -83,10 +83,10 @@ struct ArmPacket2 {
         /// @param liftTemp The current temperature of the lift motor in Celsius (0-255 range)
         ArmPacket2(float liftAngle, float liftTarget, bool swivelActivated, bool swivelLimSwitch, bool extendActivated, bool extendLimSwitch, bool liftActivated, bool liftLimSwitch, unsigned char swivelTemp, unsigned char extendTemp, unsigned char liftTemp ) : 
             liftAngle((unsigned short) (liftAngle*10000)),
-            liftTarget((unsigned short) (liftTarget*10000)), swivelTemp(swivelTemp), extendTemp(extendTemp), liftTemp(liftTemp),
+            liftTarget((unsigned short) (liftTarget*10000)), 
             swivelActivated(swivelActivated),swivelLimSwitch(swivelLimSwitch),extendActivated(extendActivated),
-            extendLimSwitch(extendLimSwitch),liftActivated(liftActivated),liftLimSwitch(liftLimSwitch)
-             {}
+            extendLimSwitch(extendLimSwitch),liftActivated(liftActivated),liftLimSwitch(liftLimSwitch),
+            swivelTemp(swivelTemp), extendTemp(extendTemp), liftTemp(liftTemp){}
         /// @brief Get the lift current angle.
         /// @return The angle in radians.
         float getLiftAngle(){

--- a/src/data/can/gripper.h
+++ b/src/data/can/gripper.h
@@ -83,10 +83,10 @@ struct GripperPacket2 {
         /// @param liftTemp The current temperature of the lift motor in Celsius (0-255 range)
         GripperPacket2(float liftAngle, float liftTarget, bool rotateActivated, bool rotateLimSwitch, bool pinchActivated, bool pinchLimSwitch, bool liftActivated, bool liftLimSwitch, unsigned char rotateTemp, unsigned char pinchTemp, unsigned char liftTemp ) : 
             liftAngle((unsigned short) (liftAngle*10000)),
-            liftTarget((unsigned short) (liftTarget*10000)), rotateTemp(rotateTemp), pinchTemp(pinchTemp), liftTemp(liftTemp),
+            liftTarget((unsigned short) (liftTarget*10000)), 
             rotateActivated(rotateActivated),rotateLimSwitch(rotateLimSwitch),pinchActivated(pinchActivated),
-            pinchLimSwitch(pinchLimSwitch),liftActivated(liftActivated),liftLimSwitch(liftLimSwitch)
-             {}
+            pinchLimSwitch(pinchLimSwitch),liftActivated(liftActivated),liftLimSwitch(liftLimSwitch), 
+            rotateTemp(rotateTemp), pinchTemp(pinchTemp), liftTemp(liftTemp){}
         /// @brief Get the lift current angle.
         /// @return The angle in radians.
         float getLiftAngle(){


### PR DESCRIPTION
Having the constructor initialize in a different order than the variables are listed in the struct causes a warning on compilation. By fixing this ordering, the warning should go away.